### PR TITLE
workaround for wallpaper module cannot parse URL well

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,8 @@ func setBingWallpaper() {
 		log.Printf("[ERR] unable to retrieve Bing image of the day: %v", err)
 		return
 	}
-
+	// append a dummy appendix for wallpaper module to recognize the filename
+	image.URL = image.URL + "/fakefilename=2020.jpg"
 	log.Printf("[INF] updating wallpaper, url: %q, copyright: %q", image.URL, image.Copyright)
 
 	if err := wallpaper.SetFromURL(image.URL); err != nil {


### PR DESCRIPTION
when running bingo, its wallpaper failed to recognize the filepath and show 'unable to set wallpaper'
make a workaround that add a end string of '/2020.jpg' to avoid wallpaper failure

C:\Users\xxx\bingo>go run main.go
[bingo] 2020/06/08 23:35:27 [INF] url:'"https://www.bing.com/th?id=OHR.LionSurfing_ROW9727597970_1920x1080.jpg&rf=LaDigue_1920x1080.jpg&pid=hp"'
[bingo] 2020/06/08 23:35:27 [INF] updating wallpaper, url: "https://www.bing.com/th?id=OHR.LionSurfing_ROW9727597970_1920x1080.jpg&rf=LaDigue_1920x1080.jpg&pid=hp", copyright: "Galápagos sea lion off the shore of Fernandina Island, Galápagos Islands, Ecuador (© Tui De Roy/Minden Pictures)"
[bingo] 2020/06/08 23:35:27 [ERR] unable to set wallpaper: open C:\Users\dalon\AppData\Local\Temp\th?id=OHR.LionSurfing_ROW9727597970_1920x1080.jpg&rf=LaDigue_1920x1080.jpg&pid=hp: The filename, directory name, or volume label syntax is incorrect.
[bingo] 2020/06/08 23:35:27 [INF] wallpaper will be updated again daily at 08:00
exit status 2